### PR TITLE
For RHEL-7.2,ping does not support -4 option

### DIFF
--- a/virt/install/runtest.sh
+++ b/virt/install/runtest.sh
@@ -821,7 +821,11 @@ EOF
          connected=0
          tries=30
          while [ $connected -eq 0 -a $tries -gt 0 ]; do
-            ping -c 1 -4 $LAB_CONTROLLER && connected=1 && break
+            if rlIsRHEL '<=7.2' ; then
+               ping -c 1 "$LAB_CONTROLLER" && connected=1 && break
+            else
+               ping -c 1 -4 "$LAB_CONTROLLER" && connected=1 && break
+            fi
             sleep 1
             tries=$(( tries - 1 ))
          done


### PR DESCRIPTION
Signed-off-by: Zhonghua Hao <zhao@redhat.com>

When I run /distribution/virt/install on RHEL-7.2,my beaker jobs failed due to ping -4.
Because RHEL-7.2 uses iputils-20121221-7.el7 and ping command does not support option -4.
So I modified the code to use ping -4 option according to RHEL version.


Failed job:https://beaker.engineering.redhat.com/jobs/3903889
https://beaker-archive.host.prod.eng.bos.redhat.com/beaker-logs/2019/11/39038/3903889/7587009/102295511/taskout.log