### PR TITLE
Add executable flag to runtest.sh

### DIFF
--- a/check-install/Makefile
+++ b/check-install/Makefile
@@ -11,6 +11,7 @@ FILES=$(METADATA) sysinfo.sh
 
 .PHONY: run
 run:
+	chmod +x ./runtest.sh
 	./runtest.sh
 
 $(METADATA):


### PR DESCRIPTION
When this task is fetched by restraint using <fetch /> element in Beaker, it fails, because runtest.sh isn't executable.
I've seen that many Beaker tasks set the executable flag, so this should be a trivial change.