### PR TITLE
Task virt/install fails Config RHEL9 NW Interface

### DIFF
--- a/virt/install/runtest.sh
+++ b/virt/install/runtest.sh
@@ -806,7 +806,7 @@ if [[ ${kvm_num} -gt 0 ]]; then
 
          nmcli conn mod $netdev master br1 connection.autoconnect yes 802-3-ethernet.mac-address $mac
          nmcli conn add type bridge con-name $brdev ifname $brdev
-         nmcli conn mod $brdev 802-3-ethernet.mac-address $mac ipv4.method auto ipv6.method auto connection.autoconnect yes bridge.forward_delay 2
+         nmcli conn mod $brdev 802-3-ethernet.clone-mac-address $mac ipv4.method auto ipv6.method auto connection.autoconnect yes bridge.forward_delay 2
 
       else
 
@@ -831,8 +831,7 @@ EOF
          chkconfig NetworkManager off
          chkconfig network on
          service network restart
-      # CB_TBD OFF elif rlIsRHEL '<9' ; then
-      else
+      elif rlIsRHEL '<9' ; then
          # Turn on NetworkManager which supports bridging on RHEL7
          systemctl start NetworkManager
          systemctl enable NetworkManager
@@ -855,12 +854,12 @@ EOF
            CB_TBD OFF echo "Problem while restoring network on $brdev"
             exit 1
          fi
-         # CB_TBD OFF else
+     else
          # NetworkManager enabled by default
-         # CB_TBD OFF nmcli conn down $netdev
-         # CB_TBD OFF nmcli conn reload
-         # CB_TBD OFF nmcli conn up $netdev
-         # CB_TBD OFF nmcli conn up $brdev
+         nmcli conn down $netdev
+         nmcli conn reload
+         nmcli conn up $netdev
+         nmcli conn up $brdev
       fi
 
       if [[ $? -ne 0 ]]; then

--- a/virt/install/runtest.sh
+++ b/virt/install/runtest.sh
@@ -804,7 +804,7 @@ if [[ ${kvm_num} -gt 0 ]]; then
       fi
       if rlIsRHEL '>=9' ; then
 
-         nmcli conn mod $netdev master br1 slave-type bridge onnection.autoconnect yes 802-3-ethernet.mac-address $mac
+         nmcli conn mod $netdev master br1 slave-type bridge connection.autoconnect yes 802-3-ethernet.mac-address $mac
          nmcli conn add type bridge con-name $brdev ifname $brdev
          nmcli conn mod $brdev 802-3-ethernet.clone-mac-address $mac ipv4.method auto ipv6.method auto connection.autoconnect yes bridge.forward_delay 2
 

--- a/virt/install/runtest.sh
+++ b/virt/install/runtest.sh
@@ -806,7 +806,7 @@ if [[ ${kvm_num} -gt 0 ]]; then
 
          nmcli conn mod $netdev master br1 slave-type bridge connection.autoconnect yes 802-3-ethernet.mac-address $mac
          nmcli conn add type bridge con-name $brdev ifname $brdev
-         nmcli conn mod $brdev 802-3-ethernet.cloned-mac-address $mac ipv4.method auto ipv6.method auto connection.autoconnect yes bridge.forward_delay 2
+         nmcli conn mod $brdev 802-3-ethernet.cloned-mac-address $mac ipv4.method auto ipv6.method auto connection.autoconnect yes bridge.forward-delay 2
 
       else
 

--- a/virt/install/runtest.sh
+++ b/virt/install/runtest.sh
@@ -831,9 +831,7 @@ EOF
          chkconfig NetworkManager off
          chkconfig network on
          service network restart
-#if 0
-      elif rlIsRHEL '<9' ; then
-#endif
+      # CB_TBD OFF elif rlIsRHEL '<9' ; then
       else
          # Turn on NetworkManager which supports bridging on RHEL7
          systemctl start NetworkManager
@@ -854,17 +852,15 @@ EOF
             tries=$(( tries - 1 ))
          done
          if [ $connected -eq 0 ]; then
-            echo "Problem while restoring network on $brdev"
+           CB_TBD OFF echo "Problem while restoring network on $brdev"
             exit 1
          fi
-#if 0
-      else
+         # CB_TBD OFF else
          # NetworkManager enabled by default
-          nmcli conn down $netdev
-          nmcli conn reload
-          nmcli conn up $netdev
-          nmcli conn up $brdev
-#endif
+         # CB_TBD OFF nmcli conn down $netdev
+         # CB_TBD OFF nmcli conn reload
+         # CB_TBD OFF nmcli conn up $netdev
+         # CB_TBD OFF nmcli conn up $brdev
       fi
 
       if [[ $? -ne 0 ]]; then

--- a/virt/install/runtest.sh
+++ b/virt/install/runtest.sh
@@ -804,7 +804,7 @@ if [[ ${kvm_num} -gt 0 ]]; then
       fi
       if rlIsRHEL '>=9' ; then
 
-         nmcli conn mod $netdev master br1 connection.autoconnect yes 802-3-ethernet.mac-address $mac
+         nmcli conn mod $netdev master br1 slave-type bridge onnection.autoconnect yes 802-3-ethernet.mac-address $mac
          nmcli conn add type bridge con-name $brdev ifname $brdev
          nmcli conn mod $brdev 802-3-ethernet.clone-mac-address $mac ipv4.method auto ipv6.method auto connection.autoconnect yes bridge.forward_delay 2
 

--- a/virt/install/runtest.sh
+++ b/virt/install/runtest.sh
@@ -804,10 +804,9 @@ if [[ ${kvm_num} -gt 0 ]]; then
       fi
       if rlIsRHEL '>=9' ; then
 
+         nmcli conn mod $netdev master br1 connection.autoconnect yes 802-3-ethernet.mac-address $mac
          nmcli conn add type bridge con-name $brdev ifname $brdev
-         nmcli conn mod $brdev 802-3-ethernet.mac-address $mac ipv4.method auto ipv6.method auto connection.autoconnect yes
-         nmcli conn mod $netdev master br1 connection.autoconnect yes
-         nmcli conn mod $netdev connection.autoconnect yes
+         nmcli conn mod $brdev 802-3-ethernet.mac-address $mac ipv4.method auto ipv6.method auto connection.autoconnect yes bridge.forward_delay 2
 
       else
 
@@ -832,7 +831,11 @@ EOF
          chkconfig NetworkManager off
          chkconfig network on
          service network restart
+#if 0
       elif rlIsRHEL '<9' ; then
+#else
+      else
+#endif
          # Turn on NetworkManager which supports bridging on RHEL7
          systemctl start NetworkManager
          systemctl enable NetworkManager
@@ -855,12 +858,14 @@ EOF
             echo "Problem while restoring network on $brdev"
             exit 1
          fi
+#if 0
       else
          # NetworkManager enabled by default
           nmcli conn down $netdev
           nmcli conn reload
           nmcli conn up $netdev
           nmcli conn up $brdev
+#endif
       fi
 
       if [[ $? -ne 0 ]]; then

--- a/virt/install/runtest.sh
+++ b/virt/install/runtest.sh
@@ -806,7 +806,7 @@ if [[ ${kvm_num} -gt 0 ]]; then
 
          nmcli conn mod $netdev master br1 slave-type bridge connection.autoconnect yes 802-3-ethernet.mac-address $mac
          nmcli conn add type bridge con-name $brdev ifname $brdev
-         nmcli conn mod $brdev 802-3-ethernet.clone-mac-address $mac ipv4.method auto ipv6.method auto connection.autoconnect yes bridge.forward_delay 2
+         nmcli conn mod $brdev 802-3-ethernet.cloned-mac-address $mac ipv4.method auto ipv6.method auto connection.autoconnect yes bridge.forward_delay 2
 
       else
 

--- a/virt/install/runtest.sh
+++ b/virt/install/runtest.sh
@@ -833,9 +833,8 @@ EOF
          service network restart
 #if 0
       elif rlIsRHEL '<9' ; then
-#else
-      else
 #endif
+      else
          # Turn on NetworkManager which supports bridging on RHEL7
          systemctl start NetworkManager
          systemctl enable NetworkManager


### PR DESCRIPTION
Guest recipes using virt/install fail in RHEL9 since the network
interface files have relocated from /etc/sysconfig/network-scripts to
/etc/NetworkManager/system-connections. The file definitions also
have been changed.